### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ Falcon.init = function(api, project, handler) {
     Falcon.API = api;
     Falcon.PROJECT = project;
     Falcon.DEFAULT_HANDLER = handler || function noop(){};
+    return Falcon;
 };
 
 Falcon.prototype.tag = function(key, value) {
@@ -148,7 +149,7 @@ Falcon.prototype.now = function() {
 Falcon.prototype.createItem = function(metric, value, options) {
     options.tags = options.tags ? (','+options.tags) : '';
 
-    var endpoint = Falcon.ENDPOINT;
+    var endpoint = options.endpoint || Falcon.ENDPOINT;
     var timestamp = this.now();
     var step = options.step || this._step;
     var counterType = options.counterType;


### PR DESCRIPTION
- 为`init`方法增加Falcon返回，从而可以使用`var Falcon = require('node-open-falcon').init();`
- 为`gauge`方法options增加endpoint参数，支持同一个实例发送时候可选不同的endpoint.
